### PR TITLE
zeus-setting input field width overflow issue

### DIFF
--- a/assets/admin/css/style.css
+++ b/assets/admin/css/style.css
@@ -355,6 +355,7 @@ Admin Styling
 	font-size: 15px;
 	border: 2px solid #eaeaea;
 	padding: 6px 10px;
+	width: auto;
 	height: 44px;
 	line-height: 1.3;
 	-webkit-transition: all 0.2s ease-in-out 0s;


### PR DESCRIPTION
zeus-setting input field [overflow issue](https://prnt.sc/20xy4jr) due to the width.